### PR TITLE
Fix widget rendering bug

### DIFF
--- a/taggit_autocomplete_jqueryui/widgets.py
+++ b/taggit_autocomplete_jqueryui/widgets.py
@@ -39,7 +39,7 @@ class TagAutocomplete(Input):
                 <li data-tag="%(name)s">
                     <span class="name">%(name)s</span>
                     <a class="remove" href="#">X</a>
-                </li>''' % {'name': tag.name})
+                </li>''' % {'name': tag})
         html += '</ul>'
         html += super(TagAutocomplete, self).render(name, value, attrs)
         html += '<input type="text" id="%s_autocomplete"/></div>' % attrs['id']


### PR DESCRIPTION
When iterating over the tags to render in the widget, `tags` can either
be a list of strings or of django-taggit `Tag` instances. Retrieving
`tag.name` only works in the latter case; fix that by just rendering
`tag` instead.